### PR TITLE
Add Quest Categories

### DIFF
--- a/backend/app/controllers/api/v1/categories_controller.rb
+++ b/backend/app/controllers/api/v1/categories_controller.rb
@@ -1,0 +1,15 @@
+class Api::V1::CategoriesController < ApplicationController
+  before_action :authenticate_user!
+
+  # GET /api/v1/categories
+  def index
+    categories = Category.order(:name)
+    render json: categories
+  end
+
+  # GET /api/v1/categories/:id
+  def show
+    category = Category.find(params[:id])
+    render json: category, include: :quests
+  end
+end

--- a/backend/app/controllers/api/v1/quests_controller.rb
+++ b/backend/app/controllers/api/v1/quests_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::QuestsController < ApplicationController
     if quest.save
       render json: quest, status: :created
     else
-      render json: { errors: quest.errors.full_messages }, status: :unprocessable_entity
+      render json: { errors: quest.errors.full_messages }, status: :unprocessable_content
     end
   end
 

--- a/backend/app/controllers/api/v1/quests_controller.rb
+++ b/backend/app/controllers/api/v1/quests_controller.rb
@@ -1,15 +1,16 @@
 class Api::V1::QuestsController < ApplicationController
   before_action :authenticate_user!
+
   # GET /api/v1/quests
   def index
-    quests = Quest.all
-    render json: quests
+    quests = Quest.includes(:category).all
+    render json: quests, include: :category
   end
 
   # GET /api/v1/quests/:id
   def show
     quest = Quest.find(params[:id])
-    render json: quest, include: :users
+    render json: quest, include: [:users, :category]
   end
 
   # POST /api/v1/quests
@@ -18,13 +19,13 @@ class Api::V1::QuestsController < ApplicationController
     if quest.save
       render json: quest, status: :created
     else
-      render json: { errors: quest.errors.full_messages }, status: :unprocessable_content
+      render json: { errors: quest.errors.full_messages }, status: :unprocessable_entity
     end
   end
 
   private
 
-    def quest_params
-      params.require(:quest).permit(:title, :description)
-    end
+  def quest_params
+    params.require(:quest).permit(:title, :description, :category_id)
+  end
 end

--- a/backend/app/controllers/api/v1/quests_controller.rb
+++ b/backend/app/controllers/api/v1/quests_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::QuestsController < ApplicationController
   # GET /api/v1/quests/:id
   def show
     quest = Quest.find(params[:id])
-    render json: quest, include: [:users, :category]
+    render json: quest, include: [ :users, :category ]
   end
 
   # POST /api/v1/quests
@@ -25,7 +25,7 @@ class Api::V1::QuestsController < ApplicationController
 
   private
 
-  def quest_params
-    params.require(:quest).permit(:title, :description, :category_id)
-  end
+    def quest_params
+      params.require(:quest).permit(:title, :description, :category_id)
+    end
 end

--- a/backend/app/models/category.rb
+++ b/backend/app/models/category.rb
@@ -1,0 +1,6 @@
+class Category < ApplicationRecord
+  has_many :quests, dependent: :destroy
+
+  validates :name, presence: true, uniqueness: true
+  validates :score, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+end

--- a/backend/app/models/quest.rb
+++ b/backend/app/models/quest.rb
@@ -1,5 +1,8 @@
 class Quest < ApplicationRecord
+  belongs_to :category
+
   validates :title, presence: true
+
   has_many :completions, dependent: :destroy
   has_many :users, through: :completions
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
       get "/me", to: "sessions#show", as: :me
       resources :quests, only: [ :index, :show, :create ]
       resources :completions, only: [ :create ]
+      resources :categories, only: [:index, :show] 
     end
   end
 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
       get "/me", to: "sessions#show", as: :me
       resources :quests, only: [ :index, :show, :create ]
       resources :completions, only: [ :create ]
-      resources :categories, only: [:index, :show] 
+      resources :categories, only: [ :index, :show ]
     end
   end
 

--- a/backend/db/migrate/20251009150229_create_categories.rb
+++ b/backend/db/migrate/20251009150229_create_categories.rb
@@ -1,0 +1,10 @@
+class CreateCategories < ActiveRecord::Migration[8.0]
+  def change
+    create_table :categories do |t|
+      t.string :name
+      t.integer :score
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/migrate/20251009162208_add_category_ref_to_quests.rb
+++ b/backend/db/migrate/20251009162208_add_category_ref_to_quests.rb
@@ -1,0 +1,5 @@
+class AddCategoryRefToQuests < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :quests, :category, null: false, foreign_key: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_02_003658) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_09_162208) do
+  create_table "categories", force: :cascade do |t|
+    t.string "name"
+    t.integer "score"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "completions", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "quest_id", null: false
@@ -26,6 +33,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_02_003658) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "category_id", null: false
+    t.index ["category_id"], name: "index_quests_on_category_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -39,4 +48,5 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_02_003658) do
 
   add_foreign_key "completions", "quests"
   add_foreign_key "completions", "users"
+  add_foreign_key "quests", "categories"
 end

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -31,3 +31,13 @@ User.create!(
 )
 
 puts "Seeded #{User.count} users."
+
+Category.destroy_all
+
+Category.create!([
+  { name: "Exploration", score: 100 },
+  { name: "Social", score: 150 },
+  { name: "Service", score: 200 }
+])
+
+puts "Seeded #{Category.count} categories."

--- a/backend/test/controllers/api/v1/quests_controller_test.rb
+++ b/backend/test/controllers/api/v1/quests_controller_test.rb
@@ -3,7 +3,8 @@ require "test_helper"
 class Api::V1::QuestsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = User.create!(name: "Test User", email: "test@example.com", password: "password123", password_confirmation: "password123", role: :student)
-    @quest = Quest.create!(title: "Test Quest", description: "A quest for testing.")
+    @category = Category.create!(name: "Testing", score: 50)
+    @quest = Quest.create!(title: "Test Quest", description: "A quest for testing.", category: @category)
   end
 
   test "should not allow unauthenticated access to index" do
@@ -33,20 +34,20 @@ class Api::V1::QuestsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should not allow unauthenticated quest creation" do
-    post api_v1_quests_url, params: { quest: { title: "New Quest", description: "Should fail." } }
+    post api_v1_quests_url, params: { quest: { title: "New Quest", description: "Should fail.", category_id: @category.id } }
     assert_response :unauthorized
     assert_includes @response.body, "Not authorized"
   end
 
   test "should allow authenticated quest creation" do
     post api_v1_login_url, params: { email: @user.email, password: "password123" }
-    post api_v1_quests_url, params: { quest: { title: "New Quest", description: "Should succeed." } }
+    post api_v1_quests_url, params: { quest: { title: "New Quest", description: "Should succeed.", category_id: @category.id } }
     assert_response :created
     assert_includes @response.body, "New Quest"
   end
 
   test "should not create quest with invalid params" do
-    post api_v1_login_url, params: { email: @user.email, password: "password123" }
+    post api_v1_login_url, params: { email: @user.email, password: "password123", category_id: @category.id }
     post api_v1_quests_url, params: { quest: { title: "" } }
     assert_response :unprocessable_content
     assert_includes @response.body, "can't be blank"

--- a/backend/test/controllers/api/v1/quests_controller_test.rb
+++ b/backend/test/controllers/api/v1/quests_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Api::V1::QuestsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @category = Category.create!(name: "Testing", score: 50)
+    @category = Category.create!(name: "Testing #{SecureRandom.hex(4)}", score: 0)
     @user = User.create!(name: "Test User", email: "test@example.com", password: "password123", password_confirmation: "password123", role: :student)
     @quest = Quest.create!(title: "Test Quest", description: "A quest for testing.", category_id: @category.id)
   end

--- a/backend/test/controllers/api/v1/quests_controller_test.rb
+++ b/backend/test/controllers/api/v1/quests_controller_test.rb
@@ -2,9 +2,9 @@ require "test_helper"
 
 class Api::V1::QuestsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @user = User.create!(name: "Test User", email: "test@example.com", password: "password123", password_confirmation: "password123", role: :student)
     @category = Category.create!(name: "Testing", score: 50)
-    @quest = Quest.create!(title: "Test Quest", description: "A quest for testing.", category: @category)
+    @user = User.create!(name: "Test User", email: "test@example.com", password: "password123", password_confirmation: "password123", role: :student)
+    @quest = Quest.create!(title: "Test Quest", description: "A quest for testing.", category_id: @category.id)
   end
 
   test "should not allow unauthenticated access to index" do

--- a/backend/test/fixtures/categories.yml
+++ b/backend/test/fixtures/categories.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  score: 1
+
+two:
+  name: MyString
+  score: 1

--- a/backend/test/fixtures/categories.yml
+++ b/backend/test/fixtures/categories.yml
@@ -1,9 +1,5 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  name: MyString
-  score: 1
-
-two:
-  name: MyString
-  score: 1
+  name: Testing
+  score: 0

--- a/backend/test/fixtures/quests.yml
+++ b/backend/test/fixtures/quests.yml
@@ -3,7 +3,9 @@
 one:
   title: MyString
   description: MyText
+  category: one
 
 two:
   title: MyString
   description: MyText
+  category: one

--- a/backend/test/models/category_test.rb
+++ b/backend/test/models/category_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Campus Quest</title>
   </head>

--- a/frontend/src/components/QuestDashboard.tsx
+++ b/frontend/src/components/QuestDashboard.tsx
@@ -113,18 +113,23 @@ export default function QuestDashboard({ currentUserId }: Props) {
     id: q.id,
     title: q.title,
     description: q.description,
+    oints: q.description,
+    category_name: q.category?.name ?? '—',
+    score: q.category?.score ?? 0,
     created_at: q.created_at,
     updated_at: q.updated_at,
   }));
 
   const columns: GridColDef[] = [
     { field: 'id', headerName: 'ID', width: 80 },
-    { field: 'title', headerName: 'Title', flex: 1 },
-    { field: 'description', headerName: 'Description', flex: 2 },
+    { field: 'title', headerName: 'Title', minWidth: 80, flex: 1 },
+    { field: 'description', headerName: 'Description', flex : 1},
+    { field: 'category_name', headerName: 'Category', flex: 1},
+    { field: 'score', headerName: 'Points', flex : 1 },
     {
       field: 'created_at',
       headerName: 'Created',
-      width: 180,
+      width: 100,
       renderCell: (params) => {
         const { display, full } = formatRelativeTimeWithTooltip(params.value);
         return (
@@ -137,7 +142,7 @@ export default function QuestDashboard({ currentUserId }: Props) {
     {
       field: 'updated_at',
       headerName: 'Updated',
-      width: 180,
+      width: 100,
       renderCell: (params) => {
         const { display, full } = formatRelativeTimeWithTooltip(params.value);
         return (
@@ -230,7 +235,7 @@ export default function QuestDashboard({ currentUserId }: Props) {
           >
             {categories.map((cat) => (
               <MenuItem key={cat.id} value={cat.id}>
-                {cat.name} ({cat.score})
+                {cat.name}
               </MenuItem>
             ))}
           </TextField>

--- a/frontend/src/components/QuestDashboard.tsx
+++ b/frontend/src/components/QuestDashboard.tsx
@@ -12,12 +12,14 @@ import {
   Snackbar,
   Alert,
   Tooltip,
+  MenuItem,
 } from '@mui/material';
 import { DataGrid, GridToolbar } from '@mui/x-data-grid';
 import type { GridColDef, GridRowsProp } from '@mui/x-data-grid';
 import { Helmet } from 'react-helmet-async';
 
-import { getQuests, createQuest, createCompletion, type Quest } from '../dao/QuestDAO';
+import { getQuests, Category, createQuest, createCompletion, type Quest } from '../dao/QuestDAO';
+import { getCategories } from '../dao/CategoryDAO';
 
 import { formatRelativeTimeWithTooltip } from '../utils/date';
 
@@ -33,6 +35,8 @@ export default function QuestDashboard({ currentUserId }: Props) {
   const [createOpen, setCreateOpen] = useState(false);
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
+  const [categoryId, setCategoryId] = useState<number | null>(null);
+  const [categories, setCategories] = useState<Category[]>([]);
 
   const [snack, setSnack] = useState<{
     open: boolean;
@@ -40,6 +44,7 @@ export default function QuestDashboard({ currentUserId }: Props) {
     severity: 'success' | 'error';
   }>({ open: false, msg: '', severity: 'success' });
 
+  // Load quests
   useEffect(() => {
     (async () => {
       try {
@@ -53,13 +58,26 @@ export default function QuestDashboard({ currentUserId }: Props) {
     })();
   }, []);
 
+  // Load categories
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await getCategories();
+        setCategories(data);
+      } catch (e: any) {
+        console.error('Failed to fetch categories:', e);
+      }
+    })();
+  }, []);
+
   const handleCreate = async () => {
     try {
-      const q = await createQuest({ title, description });
+      const q = await createQuest({ title, description, category_id: categoryId! });
       setQuests((prev) => [...prev, q]);
       setCreateOpen(false);
       setTitle('');
       setDescription('');
+      setCategoryId(null);
       setSnack({ open: true, msg: 'Quest created', severity: 'success' });
     } catch (e: any) {
       setSnack({
@@ -202,6 +220,20 @@ export default function QuestDashboard({ currentUserId }: Props) {
             value={title}
             onChange={(e) => setTitle(e.target.value)}
           />
+          <TextField
+            select
+            label="Category"
+            value={categoryId ?? ''}
+            onChange={(e) => setCategoryId(Number(e.target.value))}
+            fullWidth
+            margin="normal"
+          >
+            {categories.map((cat) => (
+              <MenuItem key={cat.id} value={cat.id}>
+                {cat.name} ({cat.score})
+              </MenuItem>
+            ))}
+          </TextField>
           <TextField
             margin="dense"
             label="Description"

--- a/frontend/src/components/QuestDashboard.tsx
+++ b/frontend/src/components/QuestDashboard.tsx
@@ -72,7 +72,7 @@ export default function QuestDashboard({ currentUserId }: Props) {
 
   const handleCreate = async () => {
     try {
-      const q = await createQuest({ title, description, category_id: categoryId! });
+      const q = await createQuest({ title, description, categoryId: categoryId! });
       setQuests((prev) => [...prev, q]);
       setCreateOpen(false);
       setTitle('');

--- a/frontend/src/dao/CategoryDAO.ts
+++ b/frontend/src/dao/CategoryDAO.ts
@@ -1,0 +1,8 @@
+import { API_BASE } from '../lib/config';
+import type { Category } from './QuestDAO';
+
+export async function getCategories(): Promise<Category[]> {
+  const res = await fetch(`${API_BASE}/categories`, { credentials: 'include' });
+  if (!res.ok) throw new Error('Failed to fetch categories');
+  return res.json();
+}

--- a/frontend/src/dao/QuestDAO.ts
+++ b/frontend/src/dao/QuestDAO.ts
@@ -56,7 +56,7 @@ export async function getQuest(id: number): Promise<Quest> {
 export async function createQuest(data: {
   title: string;
   description: string;
-  category_id: number;
+  categoryId: number;
 }): Promise<Quest> {
   const res = await fetch(`${API_BASE}/quests`, {
     method: 'POST',

--- a/frontend/src/dao/QuestDAO.ts
+++ b/frontend/src/dao/QuestDAO.ts
@@ -11,10 +11,20 @@ export interface User {
   updated_at: string;
 }
 
+export interface Category {
+  id: number;
+  name: string;
+  score: number;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface Quest {
   id: number;
   title: string;
   description: string;
+  category_id: number;
+  category: Category;
   created_at: string;
   updated_at: string;
 }
@@ -43,7 +53,7 @@ export async function getQuest(id: number): Promise<Quest> {
   return res.json();
 }
 
-export async function createQuest(data: { title: string; description: string }): Promise<Quest> {
+export async function createQuest(data: { title: string; description: string; category_id: number }): Promise<Quest> {
   const res = await fetch(`${API_BASE}/quests`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/dao/QuestDAO.ts
+++ b/frontend/src/dao/QuestDAO.ts
@@ -53,7 +53,11 @@ export async function getQuest(id: number): Promise<Quest> {
   return res.json();
 }
 
-export async function createQuest(data: { title: string; description: string; category_id: number }): Promise<Quest> {
+export async function createQuest(data: {
+  title: string;
+  description: string;
+  category_id: number;
+}): Promise<Quest> {
   const res = await fetch(`${API_BASE}/quests`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
This PR adds the ability to associate a quest "category" to a quest. A category is just that, a category, that has a "score" associated to it. This score can then be used to calculate the amount of points any particular quest gives.

When creating a quest, there is a new dropdown with a list of available categories (required).

<img width="620" height="420" alt="image" src="https://github.com/user-attachments/assets/441a4d6e-c4ce-4263-9488-13543ce0e654" />

A column for category and points has also been added to the main quest dashboard. The spacing/flex/fixed widths still need to be refined.

<img width="1136" height="186" alt="image" src="https://github.com/user-attachments/assets/ed1e09f8-ad82-43c5-b5a6-0d4e77846371" />

The seed file includes 3 categories along with associated scores.

